### PR TITLE
added support for css and js file content-type

### DIFF
--- a/src/com/d5power/net/httpd/HttpResponse.as
+++ b/src/com/d5power/net/httpd/HttpResponse.as
@@ -59,6 +59,12 @@ package com.d5power.net.httpd
 				case "xls":
 					extension="application/x-xls";
 					break;
+				case "css":
+					extension="text/css";
+					break;
+				case "js":
+					extension="text/javascript";
+					break;
 				case "txt":
 				case "log":
 					extension="text/plain";


### PR DESCRIPTION
Running an html page in the browser won't work correctly unless the content-type of css and js files are set correctly by the server.